### PR TITLE
test-audio: update to reflect reading multiple audio channels

### DIFF
--- a/tests/test-audio.cc
+++ b/tests/test-audio.cc
@@ -32,7 +32,7 @@ static void test_info(AudioFile *file, const FileInfo& info)
 static void test_read(AudioFile *file, int samples)
 {
     if (!file->get_error()) {
-        file->start(0, 1024);
+        file->start(1024);
     }
 
     int samples_read = 0;
@@ -100,7 +100,7 @@ void test_audio()
         {"2ch-44100Hz.ac3",
             {AudioError::OK, "ATSC A/52", 192000, 44100, 0, 2, AC3_T, 4608}},
         {"2ch-44100Hz-std.mpc",
-            {AudioError::OK, "Musepack", 0, 44100, 0, 2, 0.0, 6912}},
+            {AudioError::OK, "Musepack", 0, 44100, 0, 2, 0.0, 11520 / 2}}, // not sure about this one -jlu5
         {"2ch-44100Hz-v1.wma",
             {AudioError::OK, "Windows Media Audio 1", 128000, 44100, 0, 2, 0.138, 6 * 1024}},
         {"2ch-44100Hz-v2.wma",
@@ -118,7 +118,7 @@ void test_audio()
         );
         run(
             "audio read: " + name,
-            [&] () { test_read(file.get(), info.samples); }
+            [&] () { test_read(file.get(), info.samples * info.channels); }
         );
     }
 }


### PR DESCRIPTION
This fixes a build failure since the signature of `AudioFile::start()` changed, and updates tests to reflect that the no. of samples read is related to the number of channels.